### PR TITLE
空の通知が送信される問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,38 @@
 # ieee-xplore-rss-alert
 
-.clasp.json
+## claspの導入とログイン
 
 ```
-{"scriptId":"{scriptId}","rootDir": "src"}
+# 最新版では依存先の改修の問題でエラーになるためバージョン指定
+$ npm install -g @google/clasp@2.3.2
+$ exec $SHELL -l
+$ clasp login
+```
+
+## 準備
+
+### 依存関係のインストール
+
+```
+$ yarn
+```
+
+### clasp用の設定ファイルの作成
+
+```
+$ cp sample.clasp.json .clasp.json
+$ vim .clasp.json
+```
+
+`.clasp.json` の `{scriptId}` を、GASの「プロジェクトの設定」で確認できる「スクリプトID」に置き換える
+
+```
+- {"scriptId":"{scriptId}","rootDir": "src"}
++ {"scriptId":"hogehogefugafuga","rootDir": "src"}
+```
+
+## デプロイ
+
+```
+$ clasp push
 ```

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,6 +99,11 @@ function main() {
     oldPostIds = [];
   }
 
+  if (!newPosts.length) {
+    Logger.log('No new posts have been added');
+    return;
+  }
+
   const newPostIds = newPosts.map((post) => post.id);
   const postIds = [...oldPostIds, ...newPostIds];
   postIdsFile.setContent(JSON.stringify(postIds));


### PR DESCRIPTION
# PRs

- #1

# 変更内容

- RSSのタイムスタンプが変更されても、新たに追加された投稿がない場合にはSlackに通知しないように修正
- READMEの充実
